### PR TITLE
feat: add prepublish scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 /dist
 /coverage
+*.tgz

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test-watch": "jest --watch",
     "test-clear-cache": "jest --clearCache",
     "test-coverage": "jest --coverage",
-    "release": "standard-version"
+    "release": "standard-version",
+    "prepublish": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^25.2.3",


### PR DESCRIPTION
There should be called `rimraf` to remove old dist before publishing the package, but not sure about it as this package is a dependency free